### PR TITLE
No sudo for root

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -30,9 +30,13 @@ func MustReadFile(file *string) string {
 }
 
 func ExecuteCommandWithSudo(command string, args ...string) (*string, error) {
-	cmdWithArgs := append([]string{command}, args...)
+	cmd := exec.Command(command, args...)
 
-	cmd := exec.Command("sudo", cmdWithArgs...)
+	uid := os.Getuid()
+	if uid != 0 {
+		cmdWithArgs := append([]string{command}, args...)
+		cmd = exec.Command("sudo", cmdWithArgs...)
+	}
 
 	log.Debug("Executing command: ", cmd.String())
 


### PR DESCRIPTION
The function `ExecuteCommandWithSudo` was modified to make the `sudo` usage optional